### PR TITLE
Fix dependency checking in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,7 +25,7 @@ deps=("ffmpeg" "feh" "convert" "xrandr" "xdg-open" "bash" "sed")
 
 
 for i in {0..6}; do
-  which ${deps[i]} 2>&- >&-
+  which ${deps[i]} >/dev/null
   status=$?
   if [[ $status -ne 0 ]]; then 
     case "${deps[i]}" in


### PR DESCRIPTION
I found why the installer script doesn't detect dependencies correctly. Improper use of `>&-` causes an I/O error while executing `which ${deps[i]}`  and that causes it to return status code 1 every time. To fix this while still not showing the output of the command, all that needed to be done to fix it was to redirect the command's output to /dev/null.